### PR TITLE
Turn library into an automatic module (Java 9 Module)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ apply plugin: "java"
 apply plugin: "com.adarshr.test-logger"
 
 group = "com.github.bisq-network"
-version = "1.6.0.bisq.1"
+version = "1.6.0.bisq.2"
 description = """
 This project aims to provide the facility to easily implement JSON-RPC for the java programming language.
 """

--- a/build.gradle
+++ b/build.gradle
@@ -143,3 +143,9 @@ artifacts {
 }
 
 apply from: 'publishing.gradle'
+
+tasks.named('jar') {
+    manifest {
+        attributes('Automatic-Module-Name': '$group')
+    }
+}


### PR DESCRIPTION
I'm adding Java 9 Module support to Bisq2. The wallet module uses this library to make RPC calls. This change is needed to modularize the wallet module.

Relates to bisq-network/bisq2#100